### PR TITLE
Complete the documentation for containerised project #25 resolved

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Check out all related information [here](GSSoC.md)
   - StanfordCoreNLP has a dependency on Java 8. `java -version` should complete successfully with version 1.8 or higher.
   - Windows- Download as a .zip file from [here](https://stanfordnlp.github.io/CoreNLP/download.html).  
   - Linux and MacOS- Follow the instructions to download the file from [here](https://stanfordnlp.github.io/CoreNLP/download.html).  
-- Docker (if you want to set me up the Docker way)
+- Docker
   - Take a look at [this](https://docs.docker.com/install/) for detailed installation instructions for Docker on Windows, Linux and Mac systems.
   - Verify the installations by `docker --version` and `docker-compose --version`
 - You won't need to download MySQL locally to make Docker work, but it's recommended as a pre-requisite to be able to debug programs outside Docker.

--- a/README.md
+++ b/README.md
@@ -38,13 +38,10 @@ Check out all related information [here](GSSoC.md)
 - StanfordCoreNLP
   - StanfordCoreNLP has a dependency on Java 8. `java -version` should complete successfully with version 1.8 or higher.
   - Windows- Download as a .zip file from [here](https://stanfordnlp.github.io/CoreNLP/download.html).  
-  - Linux and MacOS- Follow the instructions to download the file from [here](https://stanfordnlp.github.io/CoreNLP/download.html).  
-- Docker (if you want to set me up the Docker way)
-  - Take a look at [this](https://docs.docker.com/install/) for detailed installation instructions for Docker on Windows, Linux and Mac systems.
-  - You won't need to download MySQL locally to make Docker work, but it's recommended as a pre-requisite to be able to debug programs outside Docker.
-  - Verify the installations by `docker --version` and `docker-compose --version`
+  - Linux and MacOS- Follow the instructions to download the file from [here](https://stanfordnlp.github.io/CoreNLP/download.html).
 
-#### 1. How to set me up?
+#### How to set me up?
+
 - Clone the repository
 - Create the **mapbot** database in mySQL
   -  `mysql -uroot -p -hlocalhost`
@@ -69,8 +66,20 @@ Check out all related information [here](GSSoC.md)
     1. [Python](https://realpython.com/python-virtual-environments-a-primer/#why-the-need-for-virtual-environments)
     2. [Conda](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html)
 
-#### 2. How to set me up Docker style?
-- Make sure you have Docker and Docker-Compose (refer pre-requisite steps for installation instructions)
+------
+
+#### What are some pre-requisites? (with Docker)
+
+- StanfordCoreNLP
+  - StanfordCoreNLP has a dependency on Java 8. `java -version` should complete successfully with version 1.8 or higher.
+  - Windows- Download as a .zip file from [here](https://stanfordnlp.github.io/CoreNLP/download.html).  
+  - Linux and MacOS- Follow the instructions to download the file from [here](https://stanfordnlp.github.io/CoreNLP/download.html).  
+- Docker (if you want to set me up the Docker way)
+  - Take a look at [this](https://docs.docker.com/install/) for detailed installation instructions for Docker on Windows, Linux and Mac systems.
+  - Verify the installations by `docker --version` and `docker-compose --version`
+- You won't need to download MySQL locally to make Docker work, but it's recommended as a pre-requisite to be able to debug programs outside Docker.
+
+#### How to set me up Docker style?
 - Clone the repository
 - Unzip the StanfordCoreNLP package in the repository. Make sure the StanfordCoreNLP folder you downloaded in the prerequisite steps are in the cloned repository folder.
 - Add config.py file to .gitignore to avoid pushing changes made to config

--- a/README.md
+++ b/README.md
@@ -4,53 +4,57 @@
 
 
 
-##### What I do?
+#### What I do?
 
-I aim to give users a new way to interact with Google Maps through engaging text-based conversational interfaces. 
+I aim to give users a new way to interact with Google Maps through engaging text-based conversational interfaces.
 
-##### How old am I?
+#### How old am I?
 
 I'm only a baby bot right now, I need you to feed me with logic, data and inspiration.
 
-##### What is the motivation behind building me?
+#### What is the motivation behind building me?
 
-The primary motivation of the developers of MapBot is to provide a playground to tech enthusiasts, both beginners and advanced to try algorithms, approaches and ideas while contributing to a real-life project. 
+The primary motivation of the developers of MapBot is to provide a playground to tech enthusiasts, both beginners and advanced to try algorithms, approaches and ideas while contributing to a real-life project.
 
-##### What I aspire to be one day?
+#### What I aspire to be one day?
 
 - I want to help users in the most comprehensive way.
 - I want to give 'geeks' a platform to try out all things 'cool'.
 
 ------
 
-##### Are you here for GSSoC 2020?
+#### Are you here for GSSoC 2020?
 
 Check out all related information [here](GSSoC.md)
 
 ------
 
-##### What are some pre-requisites?
+#### What are some pre-requisites?
 
--  MySQL 
-  - Install the community version of mySQL from the [official mySQL documentation page](https://dev.mysql.com/doc/mysql-installation-excerpt/5.7/en/). 
+- MySQL
+  - Install the community version of mySQL from the [official mySQL documentation page](https://dev.mysql.com/doc/mysql-installation-excerpt/5.7/en/).
   - Create root user credentials during installation.
   - Verify the installation, running the command  `mysql -uroot -p -hlocalhost` should open the mySQL monitor. (Enter the root password when prompted)
 - StanfordCoreNLP
-  - StanfordCoreNLP has a dependency on Java 8. `java -version` should complete successfully with version 1.8 or higher. 
+  - StanfordCoreNLP has a dependency on Java 8. `java -version` should complete successfully with version 1.8 or higher.
   - Windows- Download as a .zip file from [here](https://stanfordnlp.github.io/CoreNLP/download.html).  
   - Linux and MacOS- Follow the instructions to download the file from [here](https://stanfordnlp.github.io/CoreNLP/download.html).  
+- Docker (if you want to set me up the Docker way)
+  - Take a look at [this](https://docs.docker.com/install/) for detailed installation instructions for Docker on Windows, Linux and Mac systems.
+  - You won't need to download MySQL locally to make Docker work, but it's recommended as a pre-requisite to be able to debug programs outside Docker.
+  - Verify the installations by `docker --version` and `docker-compose --version`
 
-##### How to set me up?
+#### 1. How to set me up?
 - Clone the repository
 - Create the **mapbot** database in mySQL
-  -  `mysql -uroot -p -hlocalhost` 
+  -  `mysql -uroot -p -hlocalhost`
   - Enter root password when prompted
   - `create database mapbot;`
   - Verify creation of the database `show databases;`
 - Unzip the StanfordCoreNLP package in the repository and keep the file names `stanford-corenlp-x.x.x.jar` and `stanford-corenlp-x.x.x-models.jar` handy.
 - Add config.py file to .gitignore to avoid pushing changes made to config
 - Run `git rm --cached config.py`
-- Edit the config.py file with the corresponding values
+- Edit the `config.py` file with the corresponding values
   - user = "root"
   - password = <your_root_password>
   - host = "localhost"
@@ -60,18 +64,27 @@ Check out all related information [here](GSSoC.md)
   - stanford_path_to_models_jar = <your_path_to_stanford-corenlp-x.x.x-models.jar>
   - javahome = <your_path_to_jdk_bin_java.exe>
 - Install dependencies from `requirements.txt` file. Run `pip install -r requirements.txt`
-- You're all set up, run the `init.py` file. `python init.py` 
-- It is recommended that you set this project up in a virtual environment to keep the dependencies separated and for easier debugging. Here's how you can do that - 
+- You're all set up, run the `init.py` file. `python init.py`
+- It is recommended that you set this project up in a virtual environment to keep the dependencies separated and for easier debugging. Here's how you can do that -
     1. [Python](https://realpython.com/python-virtual-environments-a-primer/#why-the-need-for-virtual-environments)
     2. [Conda](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html)
 
+#### 2. How to set me up Docker style?
+- Make sure you have Docker and Docker-Compose (refer pre-requisite steps for installation instructions)
+- Clone the repository
+- Unzip the StanfordCoreNLP package in the repository. Make sure the StanfordCoreNLP folder you downloaded in the prerequisite steps are in the cloned repository folder.
+- Add config.py file to .gitignore to avoid pushing changes made to config
+- Run `git rm --cached config.py`
+- Modify *only* the following fields in `config.py` file with the corresponding values:
+  - key = <your_Google_Cloud_API_key>
+- You're all set up, kick off with `start.sh` file by running `bash start.sh`.
+
 ------
-##### How do I work?
+#### How do I work?
 
 The analysis folder contains data files for the project. The sentences.csv contains the base training dataset which is used to classify the user's input into three classes - Statement, Question, and Chat. Going through some examples would clarify the difference between statement and chat. The featuresDump.csv is the result of text pre-processing done using the code in features.py and featuresDump.py.
 
 ------
-##### Want to see me in action?
+#### Want to see me in action?
 
 Here's a [Medium article](http://bit.ly/39Y9WCq) with the some superficial explanations, there are some video links too!
-


### PR DESCRIPTION
Fixes #25.

- Provided set-up instructions as a part of the README.md and installation instructions as optional pre-requisite.
- The new documentation did not remove any existing setup instructions (added under a heading of 'How to set me up Docker style?')
-  Changed Heading level 5 to Heading level 4 style. Looks better. :man_shrugging: 

The Docker website seemed more than sufficient to guide users on how to install Docker. To avoid redundancy I just redirected users to the installation instructions on the Docker's website itself.

The issue may need to be reopened after future changes in Docker set up to keep the documentation updated.