### PR TITLE
Persist database and application volume in containerised application #14 resolved

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
             - java
         volumes:
             - java_storage:/usr/local/openjdk-11/:ro
+            - .:/usr/var
         stdin_open: true
         tty: true
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
             - MYSQL_DATABASE=mapbot
         volumes:
             - ./db-init/:/docker-entrypoint-initdb.d
+            - persistent_db:/var/lib/mysql
 
     java:
         image: openjdk:11
@@ -34,3 +35,4 @@ services:
 
 volumes:
     java_storage:
+    persistent_db:


### PR DESCRIPTION
Fixes #14.

I used `volumes` for both, as I read in the very first few lines [here](https://docs.docker.com/storage/volumes/) that volumes work both on Windows and Linux and are much more preferred than bind-mounts.

- Referred [this](https://hub.docker.com/_/mysql) for the path that MySQL stored data at and created volume `persistent_db`. The link mentions:

   > ..... /var/lib/mysql inside the container, where MySQL by default will write its data files.
  - Checked my local storage after `docker-compose up`. A new directory named `mapbot_persistent_db` with all the relevant tables was created. The folder **was** retained **after** the container was shut down.

- Referred [this](https://docs.docker.com/compose/django/#define-the-project-components) to be sure of how to mount the local project directory into the container's project directory. The example is about a Django application but I got the idea.
  - Ran with just `bash start.sh` after making a change in code. The change **was** reflected **without** needing to rebuild.

Eager to know your views, @vishakha-lall. :smile: 